### PR TITLE
Switch to publish from the gh-pages branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,7 @@ on:
       - main
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: publish
@@ -24,19 +22,10 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           runCmd: zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
+      - name: Deploy to gh-pages
+        # Skip deploy on PR builds (where build also runs for validation).
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: site
-
-  deploy:
-    # Skip deploy on PR builds (where build also runs for validation).
-    if: github.ref == 'refs/heads/main'
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/deploy-pages@v4
-        id: deployment
+          folder: site
+          branch: gh-pages


### PR DESCRIPTION
As discussed in https://github.com/p4lang/p4per/issues/8, we want to publish from the gh-pages branch, and set up per-PR preview on top of this later.