### PR TITLE
Fix PR preview comment posting issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # PR number is saved in site/ so deploy.yml can read it.
-      # workflow_run payloads don't reliably carry it.
+      # PR number is saved in site/_meta/ so deploy.yml can read it.
+      # workflow_run payloads don't reliably carry it. deploy.yml removes
+      # _meta/ before publishing so it never reaches the live site.
       - name: Build site and save PR number
         uses: devcontainers/ci@v0.3
         with:
           runCmd: |
             zensical build --clean
             pr="${{ github.event.pull_request.number }}"
-            [ -n "$pr" ] && echo "$pr" > site/.pr_number || true
+            if [ -n "$pr" ]; then
+              mkdir -p site/_meta
+              echo "$pr" > site/_meta/pr_number.txt
+            fi
       - name: Upload site artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,14 +29,15 @@ jobs:
           path: site
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
+      # Strip _meta/ before deploy so build metadata never reaches the live site.
       - name: Read PR number
         id: meta
         run: |
-          if [ -f site/.pr_number ]; then
-            pr=$(cat site/.pr_number)
-            rm site/.pr_number
+          if [ -f site/_meta/pr_number.txt ]; then
+            pr=$(cat site/_meta/pr_number.txt)
             echo "pr=$pr" >> "$GITHUB_OUTPUT"
           fi
+          rm -rf site/_meta
       - name: Deploy to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
The PR preview comment was not posted because the PR number file `.pr_number` as a hidden file was excluded by default when passing from Build to Deploy using `actions/upload-artifact@v4`. Renaming this file fixes the issue.